### PR TITLE
fix(blog): update blog post link to include date

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
       <h2>Recent Blog Posts</h2>
       <ul class="blog-list">
         <li class="blog-item">
-          <h3><a href="/blog/deep-learning-in-medical.html">Deep Learning for Medical Image Analysis</a></h3>
+          <h3><a href="/blog/2025-07-01-deep-learning-in-medical.html">Deep Learning for Medical Image Analysis</a></h3>
           <div class="blog-meta">July 1, 2025</div>
           <p>
             Exploring the application of deep learning techniques in medical imaging, with a focus on challenges


### PR DESCRIPTION
* Changed the link for the blog post "Deep Learning for Medical Image Analysis" to include the publication date in the URL.
* This improves URL structure and SEO.